### PR TITLE
Add `team` menu and `members` menu

### DIFF
--- a/bot/internal/domain/conditions/team_exists_condition.go
+++ b/bot/internal/domain/conditions/team_exists_condition.go
@@ -1,0 +1,46 @@
+package conditions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/andreychh/coopera-bot/internal/domain"
+	"github.com/andreychh/coopera-bot/pkg/botlib/core"
+	"github.com/andreychh/coopera-bot/pkg/botlib/updates/attrs"
+	telegram "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+type teamExistsCondition struct {
+	community domain.Community
+}
+
+func (t teamExistsCondition) Holds(ctx context.Context, update telegram.Update) (bool, error) {
+	id, exists := attrs.ChatID(update).Value()
+	if !exists {
+		return false, fmt.Errorf("getting chat ID from update: chat ID not found")
+	}
+	text, exists := attrs.Text(update).Value()
+	if !exists {
+		return false, fmt.Errorf("getting text from update: text not found")
+	}
+	teams, err := t.community.UserWithTelegramID(id).CreatedTeams(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, team := range teams {
+		details, err := team.Details(ctx)
+		if err != nil {
+			return false, err
+		}
+		if details.Name() == text {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func TeamExists(community domain.Community) core.Condition {
+	return teamExistsCondition{
+		community: community,
+	}
+}

--- a/bot/internal/domain/domain.go
+++ b/bot/internal/domain/domain.go
@@ -11,8 +11,13 @@ type Community interface {
 }
 
 type User interface {
+	Details(ctx context.Context) (UserDetails, error)
 	CreatedTeams(ctx context.Context) ([]Team, error)
 	CreateTeam(ctx context.Context, name string) (Team, error)
+}
+
+type UserDetails interface {
+	ID() int64
 }
 
 type Team interface {

--- a/bot/internal/domain/http/cached_member.go
+++ b/bot/internal/domain/http/cached_member.go
@@ -1,0 +1,26 @@
+package http
+
+import (
+	"context"
+
+	"github.com/andreychh/coopera-bot/internal/domain"
+	"github.com/andreychh/coopera-bot/internal/domain/transport"
+)
+
+type cachedMember struct {
+	userID int64
+	role   string
+	client transport.Client
+}
+
+func (c cachedMember) Details(ctx context.Context) (domain.MemberDetails, error) {
+	panic("not implemented")
+}
+
+func (c cachedMember) CreateTask(ctx context.Context, points int, description string) (domain.Task, error) {
+	panic("not implemented")
+}
+
+func (c cachedMember) CreatedTasks(ctx context.Context) ([]domain.Task, error) {
+	panic("not implemented")
+}

--- a/bot/internal/domain/http/http_community.go
+++ b/bot/internal/domain/http/http_community.go
@@ -17,7 +17,7 @@ type httpCommunity struct {
 func (h httpCommunity) CreateUser(ctx context.Context, tgID int64, tgUsername string) (domain.User, error) {
 	payload, err := json.Object(json.Fields{
 		"telegram_id": json.I64(tgID),
-		"Username":    json.Str(tgUsername),
+		"username":    json.Str(tgUsername),
 	}).Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("marshaling payload: %w", err)

--- a/bot/internal/domain/http/http_member.go
+++ b/bot/internal/domain/http/http_member.go
@@ -1,0 +1,29 @@
+package http
+
+import (
+	"context"
+
+	"github.com/andreychh/coopera-bot/internal/domain"
+	"github.com/andreychh/coopera-bot/internal/domain/transport"
+)
+
+type httpMember struct {
+	userID     int64
+	teamID     int64
+	dataSource transport.Client
+}
+
+func (h httpMember) Details(ctx context.Context) (domain.MemberDetails, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (h httpMember) CreateTask(ctx context.Context, points int, description string) (domain.Task, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (h httpMember) CreatedTasks(ctx context.Context) ([]domain.Task, error) {
+	// TODO implement me
+	panic("implement me")
+}

--- a/bot/internal/domain/http/http_team.go
+++ b/bot/internal/domain/http/http_team.go
@@ -2,9 +2,15 @@ package http
 
 import (
 	"context"
+	jsn "encoding/json"
+	"fmt"
+	"strconv"
 
 	"github.com/andreychh/coopera-bot/internal/domain"
+	"github.com/andreychh/coopera-bot/internal/domain/memory"
 	"github.com/andreychh/coopera-bot/internal/domain/transport"
+	"github.com/andreychh/coopera-bot/pkg/repr/json"
+	"github.com/tidwall/gjson"
 )
 
 type httpTeam struct {
@@ -13,16 +19,68 @@ type httpTeam struct {
 }
 
 func (h httpTeam) Details(ctx context.Context) (domain.TeamDetails, error) {
-	// TODO implement me
-	panic("implement me")
+	data, err := h.client.Get(ctx, transport.NewOutcomingURL("teams").
+		With("team_id", strconv.FormatInt(h.id, 10)).
+		String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return memory.TeamDetails(
+		gjson.GetBytes(data, "id").Int(),
+		gjson.GetBytes(data, "name").String(),
+	), nil
 }
 
 func (h httpTeam) AddMember(ctx context.Context, user domain.User) (domain.Member, error) {
-	// TODO implement me
-	panic("implement me")
+	details, err := user.Details(ctx)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Object(json.Fields{
+		"team_id": json.I64(h.id),
+		"user_id": json.I64(details.ID()),
+	}).Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshaling payload: %w", err)
+	}
+	_, err = h.client.Post(ctx, "memberships", payload)
+	if err != nil {
+		return nil, err
+	}
+	return httpMember{
+		userID:     details.ID(),
+		teamID:     h.id,
+		dataSource: h.client,
+	}, nil
 }
 
 func (h httpTeam) Members(ctx context.Context) ([]domain.Member, error) {
-	// TODO implement me
-	panic("implement me")
+	data, err := h.client.Get(ctx, transport.NewOutcomingURL("teams").
+		With("team_id", strconv.FormatInt(h.id, 10)).
+		String())
+	if err != nil {
+		return nil, err
+	}
+	membersJSON := gjson.GetBytes(data, "members").Raw
+	if membersJSON == "" || membersJSON == "null" {
+		return nil, fmt.Errorf("field 'members' not found in response")
+	}
+	var membersSlice []struct {
+		ID   int64  `json:"member_id"`
+		Role string `json:"role"`
+	}
+	err = jsn.Unmarshal([]byte(membersJSON), &membersSlice)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling members: %w", err)
+	}
+	members := make([]domain.Member, 0, len(membersSlice))
+	for _, m := range membersSlice {
+		members = append(members, cachedMember{
+			userID: m.ID,
+			role:   m.Role,
+			client: h.client,
+		})
+	}
+	return members, nil
 }

--- a/bot/internal/domain/http/http_user.go
+++ b/bot/internal/domain/http/http_user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/andreychh/coopera-bot/internal/domain"
+	"github.com/andreychh/coopera-bot/internal/domain/memory"
 	"github.com/andreychh/coopera-bot/internal/domain/transport"
 	"github.com/andreychh/coopera-bot/pkg/repr/json"
 	"github.com/tidwall/gjson"
@@ -13,6 +14,10 @@ import (
 type httpUser struct {
 	id     int64
 	client transport.Client
+}
+
+func (h httpUser) Details(ctx context.Context) (domain.UserDetails, error) {
+	return memory.UserDetails(h.id), nil
 }
 
 func (h httpUser) CreatedTeams(ctx context.Context) ([]domain.Team, error) {

--- a/bot/internal/domain/http/http_user_with_telegram_id.go
+++ b/bot/internal/domain/http/http_user_with_telegram_id.go
@@ -9,6 +9,7 @@ import (
 	jsn "encoding/json"
 
 	"github.com/andreychh/coopera-bot/internal/domain"
+	"github.com/andreychh/coopera-bot/internal/domain/memory"
 	domaintransport "github.com/andreychh/coopera-bot/internal/domain/transport"
 	"github.com/andreychh/coopera-bot/pkg/repr/json"
 	"github.com/tidwall/gjson"
@@ -18,6 +19,14 @@ type httpUserWithTelegramID struct {
 	telegramID int64
 	client     domaintransport.Client
 	id         atomic.Int64
+}
+
+func (h *httpUserWithTelegramID) Details(ctx context.Context) (domain.UserDetails, error) {
+	id, err := h.resolveID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving user ID: %w", err)
+	}
+	return memory.UserDetails(id), nil
 }
 
 func (h *httpUserWithTelegramID) CreatedTeams(ctx context.Context) ([]domain.Team, error) {

--- a/bot/internal/domain/memory/member_details.go
+++ b/bot/internal/domain/memory/member_details.go
@@ -1,0 +1,23 @@
+package memory
+
+import "github.com/andreychh/coopera-bot/internal/domain"
+
+type memberDetails struct {
+	id   int64
+	name string
+}
+
+func (m memberDetails) ID() int64 {
+	return m.id
+}
+
+func (m memberDetails) Name() string {
+	return m.name
+}
+
+func MemberDetails(id int64, name string) domain.MemberDetails {
+	return memberDetails{
+		id:   id,
+		name: name,
+	}
+}

--- a/bot/internal/domain/memory/user_details.go
+++ b/bot/internal/domain/memory/user_details.go
@@ -1,0 +1,17 @@
+package memory
+
+import "github.com/andreychh/coopera-bot/internal/domain"
+
+type userDetails struct {
+	id int64
+}
+
+func (u userDetails) ID() int64 {
+	return u.id
+}
+
+func UserDetails(id int64) domain.UserDetails {
+	return userDetails{
+		id: id,
+	}
+}

--- a/bot/internal/ui/views/team_menu_view.go
+++ b/bot/internal/ui/views/team_menu_view.go
@@ -31,9 +31,10 @@ func (t teamMenuView) Render(ctx context.Context, update telegram.Update) (conte
 		return nil, fmt.Errorf("getting details for team %d: %w", id, err)
 	}
 	return keyboards.Inline(
-		content.Text(fmt.Sprintf("%s menu:", details.Name())),
+		content.Text(fmt.Sprintf("Team %s:", details.Name())),
 		buttons.Matrix(
 			buttons.Row(buttons.CallbackButton("Members", protocol.ToMembersMenu(details.ID()))),
+			buttons.Row(buttons.CallbackButton("Teams", protocol.ToTeamsMenu())),
 		),
 	), nil
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the bot's team and member management functionality, as well as refactors and implements missing domain logic. The main highlights are the implementation of team existence checks during team creation, the addition of new menu behaviors for teams and members, and the completion of several domain interfaces and data access methods.